### PR TITLE
Update Zsh-Plugin-Standard link

### DIFF
--- a/material-colors.plugin.zsh
+++ b/material-colors.plugin.zsh
@@ -9,7 +9,7 @@ DIRCOLORS_CACHE_FILE="${TMPDIR:-/tmp}/zsh-${UID}/material-dircolors.zsh"
 # Dircolors
 source "${DIRCOLORS_CACHE_FILE}" 2>/dev/null || {
   # Standarized $0 handling, following:
-  # https://github.com/zdharma/Zsh-100-Commits-Club/blob/master/Zsh-Plugin-Standard.adoc
+  # https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
   0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
   0="${${(M)0:#/*}:-$PWD/$0}"
   _DIRNAME="${0:h}"


### PR DESCRIPTION
The zdharma org no longer exists, so the link to the plugin standard is currently dead. This fixes it :)